### PR TITLE
macOSでも日本語表示をするためのフォント追加指定を行った

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 # from math import*
 import tkinter.font as font
-plt.rcParams['font.family'] = 'MS Gothic'
+plt.rcParams['font.family'] = ['MS Gothic', 'Hiragino Sans']
 
 class Game:
     def __init__(self, master):


### PR DESCRIPTION
## 対応理由
macOSにMS Gothic が存在しないため以下エラーになり、日本語が表示されていなかった

ちなみに、以下のようにログが表示されていた。
```
findfont: Font family 'MS Gothic' not found.
```

## 対応内容
- matplotlib.pyplotに対してフォントファミリーを指定する箇所に `Hiragino Sans` も指定追加する形に修正した。
  - MS Gothic が見つからない場合、上記フォントが指定される形になっている

## 画面更新

対応前 | 対応後
--- | ---
<img width="1918" alt="スクリーンショット 2025-07-01 18 02 09" src="https://github.com/user-attachments/assets/79d9c9ea-cc57-4738-977a-82d71cbba180" /> | <img width="1918" alt="スクリーンショット 2025-07-01 18 02 09" src="https://github.com/user-attachments/assets/79d9c9ea-cc57-4738-977a-82d71cbba180" />

